### PR TITLE
update motsu proc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2024-12-16
+## [0.3.0] - 2024-12-17
 
 ### Added
 

--- a/crates/motsu-proc/Cargo.toml
+++ b/crates/motsu-proc/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["development-tools::testing", "cryptography::cryptocurrencies"]
 keywords = ["arbitrum", "ethereum", "stylus", "unit-tests", "tests"]
 license.workspace = true
 repository.workspace = true
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 proc-macro2.workspace = true


### PR DESCRIPTION
Updates `motsu-proc` to `0.3.0` before publishing to crates.io

- [x] Changelog
