### PR TITLE
fix: make code compatible with Rust 2024 edition

### DIFF
--- a/crates/motsu-proc/src/lib.rs
+++ b/crates/motsu-proc/src/lib.rs
@@ -5,11 +5,11 @@ use proc_macro::TokenStream;
 ///
 /// Note that it's defined before the module declarations.
 macro_rules! error {
-    ($tokens:expr, $($msg:expr),+ $(,)?) => {{
+    ($tokens:expr_2021, $($msg:expr_2021),+ $(,)?) => {{
         let error = syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+));
         return error.to_compile_error().into();
     }};
-    (@ $tokens:expr, $($msg:expr),+ $(,)?) => {{
+    (@ $tokens:expr_2021, $($msg:expr_2021),+ $(,)?) => {{
         return Err(syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+)))
     }};
 }

--- a/crates/motsu-proc/src/lib.rs
+++ b/crates/motsu-proc/src/lib.rs
@@ -5,11 +5,11 @@ use proc_macro::TokenStream;
 ///
 /// Note that it's defined before the module declarations.
 macro_rules! error {
-    ($tokens:expr_2021, $($msg:expr_2021),+ $(,)?) => {{
+    ($tokens:expr, $($msg:expr),+ $(,)?) => {{
         let error = syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+));
         return error.to_compile_error().into();
     }};
-    (@ $tokens:expr_2021, $($msg:expr_2021),+ $(,)?) => {{
+    (@ $tokens:expr, $($msg:expr),+ $(,)?) => {{
         return Err(syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+)))
     }};
 }

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -37,7 +37,7 @@
 //! Alternatively [`crate::prelude::Contract::sender_and_value`] can be used to
 //! pass additional value to the contract.
 //! To make a payable call work, user should be funded with
-//! [`crate::prelude::Account::fund`] method (there is no funding by default),
+//! [`crate::prelude::Funding::fund`] method (there is no funding by default),
 //! like in example below:
 //!
 //! ```rust


### PR DESCRIPTION
Rust 2024 edition details:
https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html

Changes applied:
- https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html
- https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html