### PR TITLE
Add ability to set Chain ID in tests (fixes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ability to get and set the Chain ID in tests via new `chain_id()` and `set_chain_id()` functions #66
+- Added ability to get and set the Chain ID in tests via new `chain_id()` and `set_chain_id()` functions #67
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ability to get and set the Chain ID in tests. #67
+- Added ability to set the chain ID in tests #67
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
+- Changed Chain ID type from `U256` to native `u64` to align with Stylus implementation. #XX
+
 ## [0.6.0] - 2025-03-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added ability to get and set the Chain ID in tests via new `chain_id()` and `set_chain_id()` functions #67
+- Added ability to get and set the Chain ID in tests. #67
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
-- Changed Chain ID type from `U256` to native `u64` to align with Stylus implementation. #XX
-
 ## [0.6.0] - 2025-03-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ability to get and set the Chain ID in tests via new `chain_id()` and `set_chain_id()` functions #66
+
 ### Changed (Breaking)
 
 ## [0.5.0] - 2025-03-05

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all = "warn"
 const-hex = { version = "1.11.1", default-features = false }
 once_cell = "1.19.0"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-stylus-sdk = { version = "=0.8.1", default-features = false }
+stylus-sdk = { version = "0.8.1", default-features = false }
 dashmap = "6.1.0"
 syn = { version = "2.0.58", features = ["full"] }
 proc-macro2 = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all = "warn"
 const-hex = { version = "1.11.1", default-features = false }
 once_cell = "1.19.0"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-stylus-sdk = { version = "0.8.1", default-features = false }
+stylus-sdk = { version = "=0.8.1", default-features = false }
 dashmap = "6.1.0"
 syn = { version = "2.0.58", features = ["full"] }
 proc-macro2 = "1.0.79"

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -18,7 +18,6 @@ use stylus_sdk::{
     host::{WasmVM, VM},
     keccak_const::Keccak256,
     prelude::StorageType,
-    testing::constants::DEFAULT_CHAIN_ID,
     ArbResult,
 };
 
@@ -39,6 +38,12 @@ use crate::{
 /// accessed twice from the same thread.
 static MOTSU_VM: Lazy<DashMap<VMContext, VMContextStorage>> =
     Lazy::new(DashMap::new);
+
+/// Same value as [`stylus_sdk::testing::constants::DEFAULT_CHAIN_ID`].
+/// We'll be able to remove this after we can enable the `stylus-test` feature,
+/// which should happen after we implement the [`stylus_sdk::testing::Host`]
+/// trait.
+const DEFAULT_CHAIN_ID: u64 = 42161;
 
 /// Context of Motsu test VM associated with the current test thread.
 #[allow(clippy::module_name_repetitions)]

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -478,16 +478,14 @@ impl VMContext {
     }
 
     /// Get the current chain ID.
-    pub(crate) fn chain_id(self) -> U256 {
+    pub fn chain_id(self) -> U256 {
         self.storage().chain_id
     }
 
-    /// Set the chain ID and return the previous value.
-    pub(crate) fn set_chain_id(self, chain_id: U256) -> U256 {
+    /// Set the chain ID.
+    pub fn set_chain_id(self, chain_id: U256) {
         let mut storage = self.storage();
-        let previous = storage.chain_id;
         storage.chain_id = chain_id;
-        previous
     }
 }
 
@@ -560,7 +558,6 @@ struct VMContextStorage {
     chain_id: U256,
 }
 
-// Custom implementation of Default for VMContextStorage to initialize chain_id
 impl Default for VMContextStorage {
     fn default() -> Self {
         Self {
@@ -571,8 +568,7 @@ impl Default for VMContextStorage {
             balances: HashMap::new(),
             return_data: None,
             return_data_size: None,
-            // Default to Ethereum mainnet chain ID (1)
-            chain_id: U256::from(1),
+            chain_id: U256::from(42161), // Arbitrum Nova chain ID
         }
     }
 }

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -39,6 +39,10 @@ use crate::{
 static MOTSU_VM: Lazy<DashMap<VMContext, VMContextStorage>> =
     Lazy::new(DashMap::new);
 
+/// The same chain ID used in Nitro Testnode.
+/// See https://github.com/OffchainLabs/nitro-testnode/blob/72cd4e5d50c2ae04ee8cb56b132ee7267b6294d2/test-node.bash#L606C123-L606C129
+const DEFAULT_CHAIN_ID: u64 = 412346;
+
 /// Context of Motsu test VM associated with the current test thread.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Hash, Eq, PartialEq, Copy, Clone)]
@@ -630,7 +634,7 @@ impl Default for VMContextStorage {
             return_data_size: None,
             persistent: Backuped::default(),
             tags: HashMap::default(),
-            chain_id: 42161, // Arbitrum One chain ID
+            chain_id: DEFAULT_CHAIN_ID,
         }
     }
 }

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -18,6 +18,7 @@ use stylus_sdk::{
     host::{WasmVM, VM},
     keccak_const::Keccak256,
     prelude::StorageType,
+    testing::constants::DEFAULT_CHAIN_ID,
     ArbResult,
 };
 
@@ -38,10 +39,6 @@ use crate::{
 /// accessed twice from the same thread.
 static MOTSU_VM: Lazy<DashMap<VMContext, VMContextStorage>> =
     Lazy::new(DashMap::new);
-
-/// The same chain ID used in Nitro Testnode.
-/// See https://github.com/OffchainLabs/nitro-testnode/blob/72cd4e5d50c2ae04ee8cb56b132ee7267b6294d2/test-node.bash#L606C123-L606C129
-const DEFAULT_CHAIN_ID: u64 = 412346;
 
 /// Context of Motsu test VM associated with the current test thread.
 #[allow(clippy::module_name_repetitions)]

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -540,12 +540,12 @@ impl VMContext {
     }
 
     /// Get the current chain ID.
-    pub fn chain_id(self) -> U256 {
+    pub(crate) fn chain_id(self) -> u64 {
         self.storage().chain_id
     }
 
     /// Set the chain ID.
-    pub fn set_chain_id(self, chain_id: U256) {
+    pub fn set_chain_id(self, chain_id: u64) {
         let mut storage = self.storage();
         storage.chain_id = chain_id;
     }
@@ -617,7 +617,7 @@ struct VMContextStorage {
     /// Account's address to tag mapping.
     tags: HashMap<Address, String>,
     /// Chain ID of the current network.
-    chain_id: U256,
+    chain_id: u64,
 }
 
 impl Default for VMContextStorage {
@@ -630,7 +630,7 @@ impl Default for VMContextStorage {
             return_data_size: None,
             persistent: Backuped::default(),
             tags: HashMap::default(),
-            chain_id: U256::from(42161), // Arbitrum Nova chain ID
+            chain_id: 42161, // Arbitrum One chain ID
         }
     }
 }

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -476,6 +476,19 @@ impl VMContext {
     fn router(self, address: Address) -> VMRouterContext {
         VMRouterContext::new(self.thread_id, address)
     }
+
+    /// Get the current chain ID.
+    pub(crate) fn chain_id(self) -> U256 {
+        self.storage().chain_id
+    }
+
+    /// Set the chain ID and return the previous value.
+    pub(crate) fn set_chain_id(self, chain_id: U256) -> U256 {
+        let mut storage = self.storage();
+        let previous = storage.chain_id;
+        storage.chain_id = chain_id;
+        previous
+    }
 }
 
 /// Read the word from location pointed by `ptr`.
@@ -528,7 +541,6 @@ unsafe fn decode_calldata(
 }
 
 /// Main storage for Motsu test VM.
-#[derive(Default)]
 struct VMContextStorage {
     /// Address of the message sender.
     msg_sender: Option<Address>,
@@ -544,6 +556,25 @@ struct VMContextStorage {
     return_data: Option<Vec<u8>>,
     // Output length of a contract call.
     return_data_size: Option<usize>,
+    /// Chain ID of the current network.
+    chain_id: U256,
+}
+
+// Custom implementation of Default for VMContextStorage to initialize chain_id
+impl Default for VMContextStorage {
+    fn default() -> Self {
+        Self {
+            msg_sender: None,
+            msg_value: None,
+            contract_address: None,
+            contracts: HashMap::new(),
+            balances: HashMap::new(),
+            return_data: None,
+            return_data_size: None,
+            // Default to Ethereum mainnet chain ID (1)
+            chain_id: U256::from(1),
+        }
+    }
 }
 
 /// Contract's account storage.

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -43,7 +43,7 @@ static MOTSU_VM: Lazy<DashMap<VMContext, VMContextStorage>> =
 /// We'll be able to remove this after we can enable the `stylus-test` feature,
 /// which should happen after we implement the [`stylus_sdk::testing::Host`]
 /// trait.
-const DEFAULT_CHAIN_ID: u64 = 42161;
+pub const DEFAULT_CHAIN_ID: u64 = 42161;
 
 /// Context of Motsu test VM associated with the current test thread.
 #[allow(clippy::module_name_repetitions)]

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -155,6 +155,7 @@ mod router;
 mod shims;
 mod storage_access;
 pub use motsu_proc::test;
+use stylus_sdk::alloy_primitives::U256;
 
 #[cfg(test)]
 mod ping_pong_tests {
@@ -746,4 +747,50 @@ mod proxies_tests {
             assert_eq!(result, TEN + ONE + ONE + ONE);
         }
     }
+}
+
+/// Get the current chain ID.
+///
+/// # Examples
+///
+/// ```rust
+/// use motsu::prelude::*;
+/// use alloy_primitives::U256;
+///
+/// #[motsu::test]
+/// fn test_chain_id() {
+///     // Default chain ID is 1 (Ethereum mainnet)
+///     assert_eq!(chain_id(), U256::from(1));
+///
+///     // Set chain ID to 11155111 (Sepolia testnet)
+///     set_chain_id(U256::from(11155111));
+///     assert_eq!(chain_id(), U256::from(11155111));
+/// }
+#[must_use]
+pub fn chain_id() -> U256 {
+    crate::context::VMContext::current().chain_id()
+}
+
+/// Set the chain ID and return the previous value.
+///
+/// # Examples
+///
+/// ```rust
+/// use motsu::prelude::*;
+/// use alloy_primitives::U256;
+///
+/// #[motsu::test]
+/// fn test_set_chain_id() {
+///     // Default chain ID is 1 (Ethereum mainnet)
+///     assert_eq!(chain_id(), U256::from(1));
+///
+///     // Set chain ID to 11155111 (Sepolia testnet)
+///     let previous = set_chain_id(U256::from(11155111));
+///     assert_eq!(previous, U256::from(1));
+///     assert_eq!(chain_id(), U256::from(11155111));
+/// }
+/// ```
+#[must_use]
+pub fn set_chain_id(chain_id: U256) -> U256 {
+    crate::context::VMContext::current().set_chain_id(chain_id)
 }

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -49,7 +49,6 @@
 //!     VMContext::current().set_chain_id(11155111);
 //!     
 //!     // Now any contract code that depends on the chain ID will use this value
-//!     // This is useful for testing EIP-712 signatures, ERC20Permit, etc.
 //! }
 //! ```
 //!

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -1130,7 +1130,7 @@ mod proxies_tests {
 
 #[cfg(test)]
 mod vm_tests {
-    use stylus_sdk::{block, prelude::*, testing::constants::DEFAULT_CHAIN_ID};
+    use stylus_sdk::{block, prelude::*};
 
     use crate as motsu;
     use crate::prelude::*;

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -759,19 +759,20 @@ mod proxies_tests {
 ///
 /// #[motsu::test]
 /// fn test_chain_id() {
-///     // Default chain ID is 1 (Ethereum mainnet)
-///     assert_eq!(chain_id(), U256::from(1));
+///     // Default chain ID is 42161 (Arbitrum Nova)
+///     assert_eq!(chain_id(), U256::from(42161));
 ///
 ///     // Set chain ID to 11155111 (Sepolia testnet)
 ///     set_chain_id(U256::from(11155111));
 ///     assert_eq!(chain_id(), U256::from(11155111));
 /// }
+/// ```
 #[must_use]
 pub fn chain_id() -> U256 {
     crate::context::VMContext::current().chain_id()
 }
 
-/// Set the chain ID and return the previous value.
+/// Set the chain ID.
 ///
 /// # Examples
 ///
@@ -781,16 +782,14 @@ pub fn chain_id() -> U256 {
 ///
 /// #[motsu::test]
 /// fn test_set_chain_id() {
-///     // Default chain ID is 1 (Ethereum mainnet)
-///     assert_eq!(chain_id(), U256::from(1));
+///     // Default chain ID is 42161 (Arbitrum Nova)
+///     assert_eq!(chain_id(), U256::from(42161));
 ///
 ///     // Set chain ID to 11155111 (Sepolia testnet)
-///     let previous = set_chain_id(U256::from(11155111));
-///     assert_eq!(previous, U256::from(1));
+///     set_chain_id(U256::from(11155111));
 ///     assert_eq!(chain_id(), U256::from(11155111));
 /// }
 /// ```
-#[must_use]
-pub fn set_chain_id(chain_id: U256) -> U256 {
+pub fn set_chain_id(chain_id: U256) {
     crate::context::VMContext::current().set_chain_id(chain_id)
 }

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -172,6 +172,7 @@ mod ping_pong_tests {
     };
 
     use crate::context::{Account, Contract};
+    use crate::{chain_id, set_chain_id};
 
     const ONE: U256 = uint!(1_U256);
     const TEN: U256 = uint!(10_U256);
@@ -473,6 +474,24 @@ mod ping_pong_tests {
         assert!(
             !pong.emitted(&Ponged { from: ping.address(), value: TEN + ONE })
         );
+    }
+
+    // Test for chain_id functionality
+    #[motsu::test]
+    fn chain_id_functions(
+        _ping: Contract<PingContract>,
+        _alice: Account,
+    ) {
+        // Default chain ID is 42161 (Arbitrum Nova)
+        assert_eq!(chain_id(), U256::from(42161));
+
+        // Set chain ID to 11155111 (Sepolia testnet)
+        set_chain_id(U256::from(11155111));
+        assert_eq!(chain_id(), U256::from(11155111));
+
+        // Set it back to the original value
+        set_chain_id(U256::from(42161));
+        assert_eq!(chain_id(), U256::from(42161));
     }
 
     // TODO: add panic assertions for emitted events

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -1128,7 +1128,6 @@ mod vm_tests {
     use crate as motsu;
     use crate::prelude::*;
 
-    /// Default Chain ID
     const ETHEREUM_SEPOLIA_CHAIN_ID: u64 = 11155111;
     const CUSTOM_CHAIN_ID: u64 = 12345678987654321;
 

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -32,7 +32,8 @@
 //!
 //! ### Global Variables
 //!
-//! Motsu allows you to manipulate certain global variables that affect the execution environment:
+//! Motsu allows you to manipulate certain global variables that affect the
+//! execution environment:
 //!
 //! #### Chain ID
 //!
@@ -42,13 +43,17 @@
 //! use motsu::prelude::*;
 //!
 //! #[motsu::test]
-//! fn test_with_custom_chain_id(contract: Contract<MyContract>, alice: Account) {
+//! fn test_with_custom_chain_id(
+//!     contract: Contract<MyContract>,
+//!     alice: Account,
+//! ) {
 //!     // Default chain ID is 42161 (Arbitrum One)
-//!     
+//!
 //!     // Set chain ID to 11155111 (Sepolia testnet)
 //!     VMContext::current().set_chain_id(11155111);
-//!     
-//!     // Now any contract code that depends on the chain ID will use this value
+//!
+//!     // Now any contract code that depends on the chain ID will use this
+//!     // value
 //! }
 //! ```
 //!

--- a/crates/motsu/src/prelude.rs
+++ b/crates/motsu/src/prelude.rs
@@ -1,5 +1,8 @@
 //! Common imports for `motsu` tests.
 pub use crate::{
-    context::{Account, Contract, ContractCall, FromTag, Funding, VMContext},
+    context::{
+        Account, Contract, ContractCall, FromTag, Funding, VMContext,
+        DEFAULT_CHAIN_ID,
+    },
     revert::ResultExt,
 };

--- a/crates/motsu/src/prelude.rs
+++ b/crates/motsu/src/prelude.rs
@@ -1,2 +1,6 @@
 //! Common imports for `motsu` tests.
-pub use crate::context::{Account, Contract, ContractCall, Funding, VMContext};
+pub use crate::{
+    chain_id,
+    context::{Account, Contract, ContractCall, Funding, VMContext},
+    set_chain_id,
+};

--- a/crates/motsu/src/prelude.rs
+++ b/crates/motsu/src/prelude.rs
@@ -2,5 +2,4 @@
 pub use crate::{
     context::{Account, Contract, ContractCall, FromTag, Funding, VMContext},
     revert::ResultExt,
-    set_chain_id,
 };

--- a/crates/motsu/src/shims.rs
+++ b/crates/motsu/src/shims.rs
@@ -146,7 +146,7 @@ unsafe extern "C" fn contract_address(address: *mut u8) {
 /// [`CHAINID`]: https://www.evm.codes/#46
 #[no_mangle]
 unsafe extern "C" fn chainid() -> u64 {
-    CHAIN_ID
+    VMContext::current().chain_id().to::<u64>()
 }
 
 /// Emits an EVM log with the given number of topics and data, the first bytes

--- a/crates/motsu/src/shims.rs
+++ b/crates/motsu/src/shims.rs
@@ -142,7 +142,7 @@ unsafe extern "C" fn contract_address(address: *mut u8) {
 ///
 /// [`CHAINID`]: https://www.evm.codes/#46
 #[no_mangle]
-pub(crate) unsafe extern "C" fn chainid() -> u64 {
+unsafe extern "C" fn chainid() -> u64 {
     VMContext::current().chain_id()
 }
 

--- a/crates/motsu/src/shims.rs
+++ b/crates/motsu/src/shims.rs
@@ -27,9 +27,6 @@ use crate::context::{
     WORD_BYTES,
 };
 
-/// Arbitrum's CHAID ID.
-const CHAIN_ID: u64 = 42161;
-
 /// Externally Owned Account (EOA) code hash (wallet account).
 const EOA_CODEHASH: &[u8; 66] =
     b"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
@@ -145,8 +142,8 @@ unsafe extern "C" fn contract_address(address: *mut u8) {
 ///
 /// [`CHAINID`]: https://www.evm.codes/#46
 #[no_mangle]
-unsafe extern "C" fn chainid() -> u64 {
-    VMContext::current().chain_id().to::<u64>()
+pub(crate) unsafe extern "C" fn chainid() -> u64 {
+    VMContext::current().chain_id()
 }
 
 /// Emits an EVM log with the given number of topics and data, the first bytes


### PR DESCRIPTION
## Description
This PR adds the ability to set the Chain ID in tests, as requested in issue #66 . This feature allows testing contracts that depend on the chain ID, such as those using EIP-712 signatures or when testing Erc20Permit functionality.

<!-- Fill in with issue number -->
Resolves #66

## Changes
- Added a `chain_id` field to the `VMContextStorage` struct
- Implemented a custom `Default` implementation to initialize the `chain_id` field with a default value of 1 (Ethereum mainnet)
- Added `chain_id()` and `set_chain_id()` methods to the `VMContext` struct
- Exposed these methods through public functions in `lib.rs`
- Updated `prelude.rs` to export these functions for easy access in tests
- Added comprehensive documentation with examples

#### PR Checklist
- [x] Tests
  - Added doctests for the new functions
  - Verified all existing tests pass with the new functionality
- [x] Documentation
  - Added comprehensive documentation with examples for the new functions
- [x] Changelog
  - Added entry in the "Unreleased" section under "Added" for the Chain ID functionality