### PR TITLE
feat: Add Additional Conversions between `PrivateKeySigner`, `Address` and `Account`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ### Added
 
 - Derived `PartialEq`, `Eq` and `Debug` for `Account`. #81
-- Enabled conversion from `PrivateKeySigner` into `Account`. #81
+- Enabled additional conversions between `PrivateKeySigner`, `Address` and `Account`. #81
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ### Added
 
 - Derived `PartialEq`, `Eq` and `Debug` for `Account`. #81
-- Enabled additional conversions between `PrivateKeySigner`, `Address` and `Account`. #81
+- Enabled additional conversions between `PrivateKeySigner`, `Address` and `Account`. #84
 
 ### Changed (Breaking)
 

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -958,15 +958,27 @@ impl From<&Account> for Address {
     }
 }
 
-impl From<&mut Account> for Address {
-    fn from(value: &mut Account) -> Self {
-        value.address
-    }
-}
-
 impl From<PrivateKeySigner> for Account {
     fn from(value: PrivateKeySigner) -> Self {
         Self { address: value.address(), private_key: value.to_bytes() }
+    }
+}
+
+impl From<&PrivateKeySigner> for Account {
+    fn from(value: &PrivateKeySigner) -> Self {
+        Self { address: value.address(), private_key: value.to_bytes() }
+    }
+}
+
+impl From<Account> for PrivateKeySigner {
+    fn from(value: Account) -> Self {
+        value.signer()
+    }
+}
+
+impl From<&Account> for PrivateKeySigner {
+    fn from(value: &Account) -> Self {
+        value.signer()
     }
 }
 
@@ -1117,6 +1129,10 @@ mod tests {
     use crate::context::VMContext;
 
     mod account {
+        use std::ops::Deref;
+
+        use alloy_signer_local::PrivateKeySigner;
+
         use super::*;
 
         #[test]
@@ -1172,7 +1188,7 @@ mod tests {
         }
 
         #[test]
-        fn account_into_signer_and_back_returns_same_account() {
+        fn account_signer_and_back_returns_same_account() {
             let old_account = Account::from_seed("seed");
             let signer = old_account.signer();
             let new_account = signer.into();
@@ -1180,9 +1196,21 @@ mod tests {
         }
 
         #[test]
+        fn account_into_signer_and_back_returns_same_account() {
+            let old_account = Account::from_seed("seed");
+            let signer: PrivateKeySigner = old_account.into();
+            let new_account = signer.into();
+            assert_eq!(old_account, new_account);
+        }
+
+        #[test]
         fn account_ref_into_address() {
-            let account = &mut Account::random();
+            let account = &Account::random();
             let address: Address = account.into();
+            assert_eq!(account.address(), address);
+
+            let account = &mut Account::random();
+            let address: Address = account.deref().into();
             assert_eq!(account.address(), address);
         }
     }

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -952,6 +952,18 @@ impl From<Account> for Address {
     }
 }
 
+impl From<&Account> for Address {
+    fn from(value: &Account) -> Self {
+        value.address
+    }
+}
+
+impl From<&mut Account> for Address {
+    fn from(value: &mut Account) -> Self {
+        value.address
+    }
+}
+
 impl From<PrivateKeySigner> for Account {
     fn from(value: PrivateKeySigner) -> Self {
         Self { address: value.address(), private_key: value.to_bytes() }
@@ -1165,6 +1177,13 @@ mod tests {
             let signer = old_account.signer();
             let new_account = signer.into();
             assert_eq!(old_account, new_account);
+        }
+
+        #[test]
+        fn account_ref_into_address() {
+            let account = &mut Account::random();
+            let address: Address = account.into();
+            assert_eq!(account.address(), address);
         }
     }
 


### PR DESCRIPTION
Implemented as utilities. Noticed I needed this when writing tests for erc20 permit.