### PR TITLE
feat: remove `Context::init` helper (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
+### Removed
+- `Context::init` helper (replaced by contract constructors – see issue #101)
+
 ### Added
 
 ### Changed (Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ## [Unreleased]
 
 ### Removed
-- `Context::init` helper (replaced by contract constructors – see issue #101)
 
 ### Added
 
 ### Changed (Breaking)
+
+- Remove `context::init` helper. #102
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
-### Removed
-
 ### Added
 
 ### Changed (Breaking)
 
-- Remove `context::init` helper. #102
+- Remove `Context::init` helper function. #102
 
 ### Changed
 

--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -836,16 +836,6 @@ impl<ST: StorageType + Router + 'static> Contract<ST> {
         Self { phantom: ::core::marker::PhantomData, address }
     }
 
-    /// Initialize the contract with an `initializer` function, and on behalf of
-    /// the given `account`.
-    pub fn init<A: Into<Address>, Output>(
-        &self,
-        sender: A,
-        initializer: impl FnOnce(&mut ST) -> Output,
-    ) -> Output {
-        initializer(&mut self.sender(sender.into()))
-    }
-
     /// Create a new contract with default storage on the random address.
     #[must_use]
     pub fn random() -> Self {


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OpenZeppelin!

Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team.

Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
-->

This PR removes the obsolete `Context::init` testing helper, now redundant thanks to Stylus contract constructors.

* Deleted the helper from [crates/motsu/src/context.rs](cci:7://file:///c:/Primary%20Drive/Code/Opensource/stylus-test-helpers/crates/motsu/src/context.rs:0:0-0:0).
* Verified that no workspace code depends on it and the remaining `init`
* Added a CHANGELOG entry under **Unreleased** documenting the removal (breaking change mitigated by constructors).

<!-- Fill in with issue number -->
Resolves #101

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [x] Tests – existing suite still passes after rebuild (no functional changes).
- [ ] Documentation – N/A (helper was internal; CHANGELOG updated).
- [x] Changelog – entry added under *Unreleased*.