### PR TITLE
add: `VM::set_block_timestamp` function 

### DIFF
--- a/crates/motsu/src/context.rs
+++ b/crates/motsu/src/context.rs
@@ -564,6 +564,11 @@ impl VM {
         storage.chain_id = chain_id;
     }
 
+    /// Set the block timestamp for the current test thread
+    pub fn set_block_timestamp(self, timestamp: u64) {
+        crate::shims::BLOCK_TIMESTAMP.set(timestamp);
+    }
+
     /// Get all events emitted by the contract at `address`.
     /// Returns a vector of [`LogData`] objects representing the events emitted
     /// by the contract.

--- a/crates/motsu/src/lib.rs
+++ b/crates/motsu/src/lib.rs
@@ -1624,7 +1624,9 @@ mod vm_tests {
     use stylus_sdk::{alloy_primitives::Address, block, prelude::*};
 
     use crate as motsu;
-    use crate::{context::DEFAULT_CHAIN_ID, prelude::*};
+    use crate::{
+        context::DEFAULT_CHAIN_ID, prelude::*, shims::DEFAULT_BLOCK_TIMESTAMP,
+    };
 
     const ETHEREUM_SEPOLIA_CHAIN_ID: u64 = 11155111;
     const CUSTOM_CHAIN_ID: u64 = 12345678987654321;
@@ -1636,6 +1638,10 @@ mod vm_tests {
     impl ChainChecker {
         fn get_chain_id(&self) -> u64 {
             block::chainid()
+        }
+
+        fn get_block_timestamp(&self) -> u64 {
+            block::timestamp()
         }
     }
 
@@ -1661,5 +1667,18 @@ mod vm_tests {
         let chain_id = contract.sender(alice).get_chain_id();
         assert_eq!(chain_id, CUSTOM_CHAIN_ID);
         assert_eq!(block::chainid(), CUSTOM_CHAIN_ID);
+    }
+
+    #[motsu::test]
+    fn block_timestamp(contract: Contract<ChainChecker>, alice: Address) {
+        let block_timestamp = contract.sender(alice).get_block_timestamp();
+        assert_eq!(block_timestamp, DEFAULT_BLOCK_TIMESTAMP);
+        assert_eq!(block::timestamp(), DEFAULT_BLOCK_TIMESTAMP);
+
+        VM::context().set_block_timestamp(0);
+
+        let block_timestamp = contract.sender(alice).get_block_timestamp();
+        assert_eq!(block_timestamp, 0);
+        assert_eq!(block::timestamp(), 0);
     }
 }

--- a/crates/motsu/src/shims.rs
+++ b/crates/motsu/src/shims.rs
@@ -18,7 +18,7 @@
 //! ```
 #![allow(dead_code)]
 #![allow(clippy::missing_safety_doc)]
-use std::slice;
+use std::{cell::Cell, slice};
 
 use tiny_keccak::{Hasher, Keccak};
 
@@ -38,6 +38,13 @@ const CA_CODEHASH: &[u8; 66] =
 /// How much ink is in 1 unit of gas.
 /// See: <https://docs.arbitrum.io/stylus/concepts/gas-metering#the-ink-price>
 const GAS_TO_INK_RATE: u64 = 10_000;
+
+// Epoch timestamp: 1st January 2025 00::00::00
+pub(crate) const DEFAULT_BLOCK_TIMESTAMP: u64 = 1_735_689_600;
+
+thread_local! {
+    pub(crate) static BLOCK_TIMESTAMP: Cell<u64> = const { Cell::new(DEFAULT_BLOCK_TIMESTAMP) }
+}
 
 /// Efficiently computes the [`keccak256`] hash of the given preimage.
 /// The semantics are equivalent to that of the EVM's [`SHA3`] opcode.
@@ -335,8 +342,7 @@ unsafe extern "C" fn delegate_call_contract(
 /// [`Block Numbers and Time`]: https://developer.arbitrum.io/time
 #[no_mangle]
 unsafe extern "C" fn block_timestamp() -> u64 {
-    // Epoch timestamp: 1st January 2025 00::00::00
-    1_735_689_600
+    BLOCK_TIMESTAMP.get()
 }
 
 /// Gets a subset of the code from the account at the given address. The


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OpenZeppelin!

Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team.

Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
-->

<!-- Fill in with issue number -->
Resolves #6

Uses `thread_local!` to create a mutable global block timestamp per test thread.

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [x] Tests
- [x] Documentation
- [ ] Changelog
